### PR TITLE
Correct rendering of maths

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Once you have identified a suitable filming location, set up the Raspberry Pi, C
 
 If there are multiple cress egg heads, try to get them all in the shot.  Remember that still images will appear a little more zoomed out than the camera preview.  Once you’re satisfied with the position of the camera and egg heads, you can press `Ctrl – C` to stop the preview.
 
-Now you’re ready to start the time lapse recording.  Firstly, we need to work out the interval time and total time in milliseconds to give to the raspistill command.  One hour is 1000 * 60 * 60 = 3600000.  One day is 3600000 * 24 = 86400000.  One week is 86400000 * 7 = 604800000.  Therefore our final command should be this:
+Now you’re ready to start the time lapse recording.  Firstly, we need to work out the interval time and total time in milliseconds to give to the raspistill command.  One hour is 1000 x 60 x 60 = 3600000.  One day is 3600000 x 24 = 86400000.  One week is 86400000 x 7 = 604800000.  Therefore our final command should be this:
 
 `raspistill –o cress_%04d.jpg –tl 3600000 –t 604800000`
 


### PR DESCRIPTION
The asterisks work fine with GH's markdown renderer, but on the RPi site the parser produces italics instead, hence I've replaced the asterisks with x's for now (which is also consistent with one of the earlier bits of maths in the prose. It would probably be more correct to use × (unicode multiplication character) which would eliminate ambiguity in case it gets rendered with a serif font, but I'm not sure how the main site's parser copes with UTF-8 yet
